### PR TITLE
Download dataset to the current directory, not parent directory.

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -26,7 +26,7 @@ def main():
     transform = transforms.Compose(
         [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
     )
-    dataset2 = datasets.MNIST("../data", train=False, download=True, transform=transform)
+    dataset2 = datasets.MNIST("./data", train=False, download=True, transform=transform)
     test_loader = torch.utils.data.DataLoader(dataset2, batch_size=64)
     acc = test(model, test_loader)
     os.makedirs(os.path.split(os.path.abspath(args.out))[0], exist_ok=True)

--- a/train.py
+++ b/train.py
@@ -66,7 +66,7 @@ def main():
     transform = transforms.Compose(
         [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
     )
-    dataset1 = datasets.MNIST("../data", train=True, download=True, transform=transform)
+    dataset1 = datasets.MNIST("./data", train=True, download=True, transform=transform)
     train_loader = torch.utils.data.DataLoader(dataset1, batch_size=args.batch_size)
     model = Net()
     optimizer = optim.Adadelta(model.parameters(), lr=args.lr)


### PR DESCRIPTION
## Motivation

I'm not sure if this repository expects PRs, but I experienced the troubles regarding dataset location.
In my case, system admin cloned this repository to `/mnist-train-eval`, and the script tried to download data to `/data`, which I didn't have permission to write there. This is due to the current code tried to download the dataset to `../data`.

Since users may not have permission to the parent directory, how about downloading it under the current directory?

Notes

- The [original code](https://github.com/pytorch/examples/blob/main/mnist/main.py) seems to share the dataset (`examples/data`) with other MNIST examples such as `mnist_rnn` and `mnist_hogwild`.
- This repository only contains a single example, so I guess we can use the current directory.

## Change

- Change download location of the MNIST dataset from `../data` to `./data`